### PR TITLE
Bring CI up to latest and greatest, drop upper bounds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+name: CI
+
 on:
   pull_request:
   push:
@@ -8,15 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.stack
-            ./.stack-work
-          key: ${{ runner.os }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('*.cabal') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ hashFiles('stack.yaml') }}-
-            ${{ runner.os }}-
+      - uses: freckle/stack-cache-action@v1.0.1
       - uses: freckle/stack-action@v2
         with:
           weeder: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,23 @@
-name: Release to Hackage
+name: Release
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches: main
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    env:
-      HACKAGE_API_KEY: ${{ secrets.HACKAGE_API_KEY }}
     steps:
       - uses: actions/checkout@v2
-      - uses: freckle/stack-upload-action@main
+
+      - id: tag
+        uses: freckle/haskell-tag-action@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: steps.tag.outputs.tag
+        uses: freckle/stack-upload-action@main
         with:
-          pvp-bounds: both
+          pvp-bounds: lower
+        env:
+          HACKAGE_API_KEY: ${{ secrets.HACKAGE_UPLOAD_API_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-## [_Unreleased_](https://github.com/freckle/hspec-junit-formatter/compare/v1.0.0.2...main)
+## [_Unreleased_](https://github.com/freckle/hspec-junit-formatter/compare/v1.0.0.3...main)
 
 None
+
+## [v1.0.0.3](https://github.com/freckle/hspec-junit-formatter/compare/v1.0.0.2...v1.0.0.3)
+
+- Remove dependencies upper bounds
 
 ## [v1.0.0.2](https://github.com/freckle/hspec-junit-formatter/compare/v1.0.0.1...v1.0.0.2)
 

--- a/hspec-junit-formatter.cabal
+++ b/hspec-junit-formatter.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: b53da3460894edaa39b2ed2833237c9daba498fc6e6fdfc05d7ee2313d29c4d3
+-- hash: bdd27756f5854047e5f1bbf5ae02d41b3043f12a0e23890533ecf208ae738a95
 
 name:           hspec-junit-formatter
-version:        1.0.0.2
+version:        1.0.0.3
 synopsis:       A JUnit XML runner/formatter for hspec
 description:    Allows hspec tests to write JUnit XML output for parsing in various tools.
 category:       Testing
@@ -39,7 +39,7 @@ library
       library
   default-extensions: BangPatterns DeriveAnyClass DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable DerivingStrategies FlexibleContexts FlexibleInstances GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses NoImplicitPrelude NoMonomorphismRestriction OverloadedStrings RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TypeApplications TypeFamilies
   build-depends:
-      base <5
+      base
     , conduit
     , directory
     , exceptions

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: hspec-junit-formatter
-version: 1.0.0.2
+version: 1.0.0.3
 github: "freckle/hspec-junit-formatter"
 license: MIT
 author: "Freckle R&D"
@@ -15,7 +15,7 @@ synopsis: A JUnit XML runner/formatter for hspec
 description: Allows hspec tests to write JUnit XML output for parsing in various tools.
 
 dependencies:
-  - base < 5
+  - base
 
 default-extensions:
   - BangPatterns


### PR DESCRIPTION
This is following the patterns of https://github.com/freckle/faktory_worker_haskell/pull/59

The only way this really differs it that it makes the CHANGELOG update too.