### PR TITLE
Add file and line attributes

### DIFF
--- a/library/Test/Hspec/JUnit.hs
+++ b/library/Test/Hspec/JUnit.hs
@@ -8,6 +8,7 @@ module Test.Hspec.JUnit
 
 import Prelude
 
+import Control.Applicative ((<|>))
 import Data.Conduit (runConduitRes, (.|))
 import Data.Conduit.Combinators (sinkFile)
 import Data.Conduit.List (sourceList)
@@ -79,7 +80,8 @@ groupItems = Map.toList . Map.fromListWith (<>) . fmap group
 itemToTestCase
   :: (FilePath -> FilePath) -> Text -> Text -> Item -> Schema.TestCase
 itemToTestCase applyPrefix group name item = Schema.TestCase
-  { testCaseLocation = toSchemaLocation <$> itemResultLocation item
+  { testCaseLocation =
+    toSchemaLocation <$> (itemResultLocation item <|> itemLocation item)
   , testCaseClassName = group
   , testCaseName = name
   , testCaseDuration = unSeconds $ itemDuration item

--- a/library/Test/Hspec/JUnit.hs
+++ b/library/Test/Hspec/JUnit.hs
@@ -114,9 +114,7 @@ itemToTestCase applyPrefix group name item = Schema.TestCase
  where
   toSchemaLocation Location {..} = Schema.Location
     { Schema.locationFile = locationFile
-    , Schema.locationLine = if locationLine >= 0
-      then fromIntegral locationLine
-      else 0
+    , Schema.locationLine = fromIntegral $ max 0 locationLine
     }
 
   prefixLocation mLocation str = case mLocation of

--- a/library/Test/Hspec/JUnit/Schema.hs
+++ b/library/Test/Hspec/JUnit/Schema.hs
@@ -2,6 +2,7 @@ module Test.Hspec.JUnit.Schema
   ( Suites(..)
   , Suite(..)
   , TestCase(..)
+  , Location(..)
   , Result(..)
   ) where
 
@@ -9,6 +10,7 @@ import Prelude
 
 import Data.Text (Text)
 import Data.Time (UTCTime)
+import Numeric.Natural
 
 data Suites = Suites
   { suitesName :: Text
@@ -24,10 +26,17 @@ data Suite = Suite
   deriving stock Show
 
 data TestCase = TestCase
-  { testCaseClassName :: Text
+  { testCaseLocation :: Maybe Location
+  , testCaseClassName :: Text
   , testCaseName :: Text
   , testCaseDuration :: Double
   , testCaseResult :: Maybe Result
+  }
+  deriving stock Show
+
+data Location = Location
+  { locationFile :: FilePath
+  , locationLine :: Natural
   }
   deriving stock Show
 

--- a/tests/golden.xml
+++ b/tests/golden.xml
@@ -8,7 +8,12 @@
     timestamp="2021-05-17T15:36:10.205608409Z"
     tests="2" failures="1" errors="0" skipped="0">
     <properties/>
-    <testcase name="has a failure" classname="Some section" time="0.000015537">
+    <testcase
+      file="tests/ExampleSpec.hs"
+      line="18"
+      name="has a failure"
+      classname="Some section"
+      time="0.000015537">
       <failure type="error">tests/ExampleSpec.hs:18:7
 
 expected: &#34;False&#34;
@@ -30,6 +35,8 @@ expected: &#34;False&#34;
     tests="3" failures="0" errors="0" skipped="1">
     <properties/>
     <testcase
+      file="tests/ExampleSpec.hs"
+      line="26"
       name="gets skipped"
       classname="Some section/A grouped context"
       time="0.000006765">

--- a/tests/golden.xml
+++ b/tests/golden.xml
@@ -21,6 +21,8 @@ expected: &#34;False&#34;
 </failure>
     </testcase>
     <testcase
+      file="tests/ExampleSpec.hs"
+      line="15"
       name="has an expectation"
       classname="Some section"
       time="0.000016818"/>
@@ -44,10 +46,14 @@ expected: &#34;False&#34;
 some reason</skipped>
     </testcase>
     <testcase
+      file="tests/ExampleSpec.hs"
+      line="23"
       name="also happens in a group"
       classname="Some section/A grouped context"
       time="0.000007421"/>
     <testcase
+      file="tests/ExampleSpec.hs"
+      line="21"
       name="happens in a group"
       classname="Some section/A grouped context"
       time="0.000006823"/>


### PR DESCRIPTION
Location information isn't an official part of the JUnit XML spec, so
various conventions have emerged for reporting locations such as within
the name attribute, inferring from the classname using project structure
assumptions, or including it in the content of the testcase node (as we
do).

At least one tool* that reads JUnit reports will look for file and
line attributes if present on the testcase node. To better support this
and any similarly-behaving tools, let's add them.

\* mikepenz/action-junit-report
