### PR TITLE
Add hspecJUnit runners and env-based configuration

### DIFF
--- a/README.lhs
+++ b/README.lhs
@@ -14,16 +14,17 @@ import Text.Markdown.Unlit ()
 
 ```haskell
 import Test.Hspec
-import Test.Hspec.Core.Runner (defaultConfig, hspecWith)
 import Test.Hspec.JUnit
+import System.Environment (setEnv)
 
 main :: IO ()
 main = do
-  let
-    junitConfig = setJUnitConfigOutputDirectory "/tmp" $ defaultJUnitConfig "my-tests"
-    hspecConfig = configWithJUnit junitConfig defaultConfig
+  -- Most likely done in your CI setup
+  setEnv "JUNIT_ENABLED" "1"
+  setEnv "JUNIT_OUTPUT_DIRECTORY" "/tmp"
+  setEnv "JUNIT_SUITE_NAME" "my-tests"
 
-  hspecWith hspecConfig spec
+  hspecJUnit spec
 
 spec :: Spec
 spec = describe "Addition" $ do

--- a/hspec-junit-formatter.cabal
+++ b/hspec-junit-formatter.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9324c4f71306cfa3e9d9cdbde6d0fe8fdce2e454e238ba1e200127ddf6c1261e
+-- hash: 04b667e01794b741f3decdf48f8f7af79a0d5eb86777c6b30b643cd794270702
 
 name:           hspec-junit-formatter
 version:        1.0.2.2
@@ -31,9 +31,11 @@ source-repository head
 
 library
   exposed-modules:
+      Test.Hspec.Core.Runner.Ext
       Test.HSpec.JUnit
       Test.Hspec.JUnit
       Test.Hspec.JUnit.Config
+      Test.Hspec.JUnit.Config.Env
       Test.HSpec.JUnit.Render
       Test.Hspec.JUnit.Render
       Test.HSpec.JUnit.Schema

--- a/library/Test/Hspec/Core/Runner/Ext.hs
+++ b/library/Test/Hspec/Core/Runner/Ext.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE CPP #-}
+
+-- | Compatibility module for 'configAvailableFormatters'
+--
+-- This feature is only available in hspec >= 2.9. Note that this module doesn't
+-- do anything to backport the feature; it just supplies a function that will
+-- use it when possible and safely no-op when not.
+--
+module Test.Hspec.Core.Runner.Ext
+  ( configAddAvailableFormatter
+  ) where
+
+import Prelude
+
+import Test.Hspec.Core.Format (Format, FormatConfig)
+import Test.Hspec.Core.Runner (Config(..))
+
+configAddAvailableFormatter
+  :: String -> (FormatConfig -> IO Format) -> Config -> Config
+#if MIN_VERSION_hspec_core(2,9,0)
+configAddAvailableFormatter name format config = config
+  { configAvailableFormatters =
+    configAvailableFormatters config <> [(name, format)]
+  }
+#else
+configAddAvailableFormatter _ _ = id
+#endif

--- a/library/Test/Hspec/JUnit.hs
+++ b/library/Test/Hspec/JUnit.hs
@@ -1,5 +1,14 @@
 module Test.Hspec.JUnit
-  ( configWithJUnit
+  (
+  -- * Runners
+    hspecJUnit
+  , hspecJUnitWith
+
+  -- * Directly modifying 'Config'
+  , configWithJUnit
+  , configWithJUnitAvailable
+
+  -- * Actual format function
   , junitFormat
 
   -- * Configuration
@@ -22,15 +31,54 @@ import System.Directory (createDirectoryIfMissing)
 import System.FilePath (splitFileName)
 import Test.Hspec.Core.Format
 import Test.Hspec.Core.Runner
+import Test.Hspec.Core.Runner.Ext
+import Test.Hspec.Core.Spec (Spec)
 import Test.Hspec.JUnit.Config
+import Test.Hspec.JUnit.Config.Env
 import Test.Hspec.JUnit.Render (renderJUnit)
 import qualified Test.Hspec.JUnit.Schema as Schema
 import Text.XML.Stream.Render (def, renderBytes)
+
+-- | Like 'hspec' but adds JUNit functionality
+--
+-- To actually /use/ the JUnit format, you must set @JUNIT_ENABLED=1@ in the
+-- environment; by default, this function just behaves like 'hspec'.
+--
+-- (If using hspec >= 2.9, running tests with @--test-arguments="-f junit"@ also
+-- works.)
+--
+-- All configuration of the JUnit report occurs through environment variables.
+--
+-- See "Test.Hspec.JUnit.Config" and "Test.Hspec.JUnit.Config.Env".
+--
+hspecJUnit :: Spec -> IO ()
+hspecJUnit = hspecJUnitWith defaultConfig
+
+-- | 'hspecJUnit' but built on a non-default 'Config'
+hspecJUnitWith :: Config -> Spec -> IO ()
+hspecJUnitWith config spec = do
+  junitEnabled <- envJUnitEnabled
+  junitConfig <- envJUnitConfig
+
+  let
+    modify = if junitEnabled then configWithJUnit junitConfig else id
+    base = configWithJUnitAvailable junitConfig config
+
+  hspecWith (modify base) spec
 
 -- | Modify an Hspec 'Config' to use 'junitFormat'
 configWithJUnit :: JUnitConfig -> Config -> Config
 configWithJUnit junitConfig config =
   config { configFormat = Just $ junitFormat junitConfig }
+
+-- | Modify an Hspec 'Config' to have the 'junitFormat' /available/
+--
+-- Adds @junit@ to the list of available options for @-f, --format@.
+--
+-- __NOTE__: This only works with hspec >= 2.9, otherwise it is a no-op.
+--
+configWithJUnitAvailable :: JUnitConfig -> Config -> Config
+configWithJUnitAvailable = configAddAvailableFormatter "junit" . junitFormat
 
 -- | Hspec 'configFormat' that generates a JUnit report
 junitFormat :: JUnitConfig -> FormatConfig -> IO Format

--- a/library/Test/Hspec/JUnit/Config.hs
+++ b/library/Test/Hspec/JUnit/Config.hs
@@ -6,6 +6,7 @@ module Test.Hspec.JUnit.Config
   , setJUnitConfigOutputDirectory
   , setJUnitConfigOutputName
   , setJUnitConfigOutputFile
+  , setJUnitConfigSuiteName
   , setJUnitConfigSourcePathPrefix
 
   -- * Use
@@ -62,6 +63,9 @@ setJUnitConfigOutputName x config = config { junitConfigOutputName = x }
 --
 setJUnitConfigOutputFile :: FilePath -> JUnitConfig -> JUnitConfig
 setJUnitConfigOutputFile x config = config { junitConfigOutputFile = Just x }
+
+setJUnitConfigSuiteName :: Text -> JUnitConfig -> JUnitConfig
+setJUnitConfigSuiteName x config = config { junitConfigSuiteName = x }
 
 -- | Set a prefix to apply to source paths in the report
 --

--- a/library/Test/Hspec/JUnit/Config/Env.hs
+++ b/library/Test/Hspec/JUnit/Config/Env.hs
@@ -1,0 +1,48 @@
+-- | Load a 'JUnitConfig' using environment variables
+module Test.Hspec.JUnit.Config.Env
+    ( envJUnitEnabled
+    , envJUnitConfig
+    ) where
+
+import Prelude
+
+import Data.Semigroup (Endo(..))
+import Data.Text (pack)
+import System.Directory (getCurrentDirectory)
+import System.Environment (lookupEnv)
+import System.FilePath (takeBaseName)
+import Test.Hspec.JUnit.Config
+
+-- | Is @JUNIT_ENABLED=1@ set in the environment?
+envJUnitEnabled :: IO Bool
+envJUnitEnabled = (== Just "1") <$> lookupEnv (envPrefix <> "ENABLED")
+
+-- | Produce a 'JUnitConfig' by reading environment variables
+--
+-- Variable names align with setter functions from "Test.Hspec.JUnit.Config":
+--
+-- * @JUNIT_OUTPUT_DIRECTORY@ 'setJUnitConfigOutputDirectory'
+-- * @JUNIT_OUTPUT_NAME@ 'setJUnitConfigOutputName
+-- * and so on
+--
+envJUnitConfig :: IO JUnitConfig
+envJUnitConfig = do
+  modify <- appEndo . foldMap Endo <$> sequence
+    [ lookupEnvOverride "OUTPUT_DIRECTORY" setJUnitConfigOutputDirectory
+    , lookupEnvOverride "OUTPUT_NAME" setJUnitConfigOutputName
+    , lookupEnvOverride "OUTPUT_FILE" setJUnitConfigOutputFile
+    , lookupEnvOverride "SUITE_NAME" $ setJUnitConfigSuiteName . pack
+    , lookupEnvOverride "SOURCE_PATH_PREFIX" setJUnitConfigSourcePathPrefix
+    ]
+
+  modify . defaultJUnitConfig . pack . takeBaseName <$> getCurrentDirectory
+
+lookupEnvOverride
+  :: String
+  -> (String -> JUnitConfig -> JUnitConfig)
+  -> IO (JUnitConfig -> JUnitConfig)
+lookupEnvOverride name setter =
+  maybe id setter <$> lookupEnv (envPrefix <> name)
+
+envPrefix :: String
+envPrefix = "JUNIT_"


### PR DESCRIPTION
The primary purpose of this commit is to simplify usage to just:

```hs
main :: IO
main = hspecJUnit Spec.spec
```

This necessitated configuration through `JUNIT_`-prefixed environment
variables, implemented in the new `Config.Env` module.

In support of this, we also get:

- `hspecJUnitWith`

  `hspecJUnit` is to `hspec` as `hspecJUnitWith` is to `hspecWith`. This will be
  useful in our projects that perform further per-suite configuration.

- `configAvailableFormatters` support, when possible

  In hspec-2.9, we can add ourselves to the `-f` option for conditionally
  running with our format function. This obviates `JUNIT_ENABLED`, but
  we'll support that too.
