### PR TITLE
Use `Test.Hspec.Api.Format.V1`

### DIFF
--- a/hspec-junit-formatter.cabal
+++ b/hspec-junit-formatter.cabal
@@ -1,10 +1,8 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: 4551a50d9a220eea22c08cc0037a21dae933f03a9365f827e82b192b0b562369
 
 name:           hspec-junit-formatter
 version:        1.1.0.2
@@ -37,6 +35,7 @@ library
       Test.Hspec.JUnit.Config.Env
       Test.Hspec.JUnit.Render
       Test.Hspec.JUnit.Schema
+      Test.Hspec.JUnitFormatter
   other-modules:
       Paths_hspec_junit_formatter
   hs-source-dirs:
@@ -72,6 +71,7 @@ library
     , directory
     , exceptions
     , filepath
+    , hspec-api >=2.10 && <3
     , hspec-core >=2.8.1
     , iso8601-time
     , text

--- a/library/Test/Hspec/JUnit.hs
+++ b/library/Test/Hspec/JUnit.hs
@@ -33,10 +33,12 @@ import Test.Hspec.Core.Format
 import Test.Hspec.Core.Runner
 import Test.Hspec.Core.Runner.Ext
 import Test.Hspec.Core.Spec (Spec)
+import Test.Hspec.Api.Format.V1 (liftFormatter)
 import Test.Hspec.JUnit.Config
 import Test.Hspec.JUnit.Config.Env
 import Test.Hspec.JUnit.Render (renderJUnit)
 import qualified Test.Hspec.JUnit.Schema as Schema
+import Test.Hspec.JUnitFormatter (formatterWith)
 import Text.XML.Stream.Render (def, renderBytes)
 
 -- | Like 'hspec' but adds JUNit functionality
@@ -82,118 +84,4 @@ configWithJUnitAvailable = configAddAvailableFormatter "junit" . junitFormat
 
 -- | Hspec 'configFormat' that generates a JUnit report
 junitFormat :: JUnitConfig -> FormatConfig -> IO Format
-junitFormat junitConfig _config = pure $ \case
-  Started -> pure ()
-  GroupStarted _ -> pure ()
-  GroupDone _ -> pure ()
-  Progress _ _ -> pure ()
-  ItemStarted _ -> pure ()
-  ItemDone _ _ -> pure ()
-  Done paths -> do
-    time <- getCurrentTime
-
-    let (directory, _) = splitFileName file
-    createDirectoryIfMissing True directory
-
-    let
-      groups = groupItems paths
-      output = Schema.Suites
-        { suitesName = suiteName
-        , suitesSuites = groups <&> \(group, items) -> do
-          let
-            suite xs = Schema.Suite
-              { suiteName = group
-              , suiteTimestamp = time
-              , suiteCases = xs
-              }
-          suite $ uncurry (itemToTestCase applyPrefix group) <$> items
-        }
-
-    runConduitRes
-      $ sourceList [output]
-      .| renderJUnit
-      .| renderBytes def
-      .| sinkFile file
- where
-  file = getJUnitConfigOutputFile junitConfig
-  suiteName = getJUnitConfigSuiteName junitConfig
-  applyPrefix = getJUnitPrefixSourcePath junitConfig
-
-groupItems :: [(Path, Item)] -> [(Text, [(Text, Item)])]
-groupItems = Map.toList . Map.fromListWith (<>) . fmap group
- where
-  group ((path, name), item) =
-    (T.intercalate "/" $ pack <$> path, [(pack name, item)])
-
-itemToTestCase
-  :: (FilePath -> FilePath) -> Text -> Text -> Item -> Schema.TestCase
-itemToTestCase applyPrefix group name item = Schema.TestCase
-  { testCaseLocation =
-    toSchemaLocation applyPrefix
-      <$> (itemResultLocation item <|> itemLocation item)
-  , testCaseClassName = group
-  , testCaseName = name
-  , testCaseDuration = unSeconds $ itemDuration item
-  , testCaseResult = case itemResult item of
-    Success -> Nothing
-    Pending mLocation mMessage ->
-      Just $ Schema.Skipped $ prefixLocation mLocation $ prefixInfo $ maybe
-        ""
-        pack
-        mMessage
-    Failure mLocation reason ->
-      Just
-        $ Schema.Failure "error"
-        $ prefixLocation mLocation
-        $ prefixInfo
-        $ case reason of
-            Error _ err -> pack $ show err
-            NoReason -> "no reason"
-            Reason err -> pack err
-            ExpectedButGot preface expected actual ->
-              prefixInfo
-                $ T.unlines
-                $ pack
-                <$> fromMaybe "" preface
-                : (foundLines "expected" expected
-                  <> foundLines " but got" actual
-                  )
-  }
- where
-  prefixLocation mLocation str = case mLocation of
-    Nothing -> str
-    Just Location {..} ->
-      mconcat
-          [ pack $ applyPrefix locationFile
-          , ":"
-          , pack $ show locationLine
-          , ":"
-          , pack $ show locationColumn
-          , "\n"
-          ]
-        <> str
-  prefixInfo str
-    | T.null $ T.strip $ pack $ itemInfo item = str
-    | otherwise = pack (itemInfo item) <> "\n\n" <> str
-
-itemResultLocation :: Item -> Maybe Location
-itemResultLocation item = case itemResult item of
-  Success -> Nothing
-  Pending mLocation _ -> mLocation
-  Failure mLocation _ -> mLocation
-
-toSchemaLocation :: (FilePath -> FilePath) -> Location -> Schema.Location
-toSchemaLocation applyPrefix Location {..} = Schema.Location
-  { Schema.locationFile = applyPrefix locationFile
-  , Schema.locationLine = fromIntegral $ max 0 locationLine
-  }
-
-unSeconds :: Seconds -> Double
-unSeconds (Seconds x) = x
-
-foundLines :: Show a => Text -> a -> [String]
-foundLines msg found = case lines' of
-  [] -> []
-  first : rest ->
-    unpack (msg <> ": " <> first) : (unpack . (T.replicate 9 " " <>) <$> rest)
-  where lines' = T.lines . pack $ show found
+junitFormat = snd . liftFormatter . formatterWith

--- a/library/Test/Hspec/JUnitFormatter.hs
+++ b/library/Test/Hspec/JUnitFormatter.hs
@@ -1,0 +1,159 @@
+module Test.Hspec.JUnitFormatter
+  ( use
+  , register
+  , formatter
+  , formatterWith
+  , module Api
+  ) where
+import Prelude
+
+import Control.Applicative ((<|>))
+import Data.Conduit (runConduitRes, (.|))
+import Data.Conduit.Combinators (sinkFile)
+import Data.Conduit.List (sourceList)
+import Data.Functor ((<&>))
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
+import Data.Text (Text, pack, unpack)
+import qualified Data.Text as T
+import Data.Time (getCurrentTime)
+import System.Directory (createDirectoryIfMissing)
+import System.FilePath (splitFileName)
+import Test.Hspec.Api.Format.V1 as Api
+import Test.Hspec.JUnit.Config
+import Test.Hspec.JUnit.Config.Env
+import Test.Hspec.JUnit.Render (renderJUnit)
+import qualified Test.Hspec.JUnit.Schema as Schema
+import Text.XML.Stream.Render (def, renderBytes)
+
+-- | Make `formatter` available for use with @--format@ and use it by default.
+use :: SpecWith a -> SpecWith a
+use = (modifyConfig (useFormatter formatter) >>)
+
+-- | Make `formatter` available for use with @--format@.
+register :: SpecWith a -> SpecWith a
+register = (modifyConfig (registerFormatter formatter) >>)
+
+
+formatter :: (String, FormatConfig -> IO Format)
+formatter = ("junit", \_config -> format <$> envJUnitConfig)
+
+formatterWith :: JUnitConfig -> (String, FormatConfig -> IO Format)
+formatterWith junitConfig = ("junit", \_config -> return $ format junitConfig)
+
+format :: JUnitConfig -> Format
+format junitConfig = \case
+  Started -> pure ()
+  GroupStarted _ -> pure ()
+  GroupDone _ -> pure ()
+  Progress _ _ -> pure ()
+  ItemStarted _ -> pure ()
+  ItemDone _ _ -> pure ()
+  Done paths -> do
+    time <- getCurrentTime
+
+    let (directory, _) = splitFileName file
+    createDirectoryIfMissing True directory
+
+    let
+      groups = groupItems paths
+      output = Schema.Suites
+        { suitesName = suiteName
+        , suitesSuites = groups <&> \(group, items) -> do
+          let
+            suite xs = Schema.Suite
+              { suiteName = group
+              , suiteTimestamp = time
+              , suiteCases = xs
+              }
+          suite $ uncurry (itemToTestCase applyPrefix group) <$> items
+        }
+
+    runConduitRes
+      $ sourceList [output]
+      .| renderJUnit
+      .| renderBytes def
+      .| sinkFile file
+ where
+  file = getJUnitConfigOutputFile junitConfig
+  suiteName = getJUnitConfigSuiteName junitConfig
+  applyPrefix = getJUnitPrefixSourcePath junitConfig
+
+groupItems :: [(Path, Item)] -> [(Text, [(Text, Item)])]
+groupItems = Map.toList . Map.fromListWith (<>) . fmap group
+ where
+  group ((path, name), item) =
+    (T.intercalate "/" $ pack <$> path, [(pack name, item)])
+
+itemToTestCase
+  :: (FilePath -> FilePath) -> Text -> Text -> Item -> Schema.TestCase
+itemToTestCase applyPrefix group name item = Schema.TestCase
+  { testCaseLocation =
+    toSchemaLocation applyPrefix
+      <$> (itemResultLocation item <|> itemLocation item)
+  , testCaseClassName = group
+  , testCaseName = name
+  , testCaseDuration = unSeconds $ itemDuration item
+  , testCaseResult = case itemResult item of
+    Success -> Nothing
+    Pending mLocation mMessage ->
+      Just $ Schema.Skipped $ prefixLocation mLocation $ prefixInfo $ maybe
+        ""
+        pack
+        mMessage
+    Failure mLocation reason ->
+      Just
+        $ Schema.Failure "error"
+        $ prefixLocation mLocation
+        $ prefixInfo
+        $ case reason of
+            Error _ err -> pack $ show err
+            NoReason -> "no reason"
+            Reason err -> pack err
+            ExpectedButGot preface expected actual ->
+              prefixInfo
+                $ T.unlines
+                $ pack
+                <$> fromMaybe "" preface
+                : (foundLines "expected" expected
+                  <> foundLines " but got" actual
+                  )
+  }
+ where
+  prefixLocation mLocation str = case mLocation of
+    Nothing -> str
+    Just Location {..} ->
+      mconcat
+          [ pack $ applyPrefix locationFile
+          , ":"
+          , pack $ show locationLine
+          , ":"
+          , pack $ show locationColumn
+          , "\n"
+          ]
+        <> str
+  prefixInfo str
+    | T.null $ T.strip $ pack $ itemInfo item = str
+    | otherwise = pack (itemInfo item) <> "\n\n" <> str
+
+itemResultLocation :: Item -> Maybe Location
+itemResultLocation item = case itemResult item of
+  Success -> Nothing
+  Pending mLocation _ -> mLocation
+  Failure mLocation _ -> mLocation
+
+toSchemaLocation :: (FilePath -> FilePath) -> Location -> Schema.Location
+toSchemaLocation applyPrefix Location {..} = Schema.Location
+  { Schema.locationFile = applyPrefix locationFile
+  , Schema.locationLine = fromIntegral $ max 0 locationLine
+  }
+
+unSeconds :: Seconds -> Double
+unSeconds (Seconds x) = x
+
+foundLines :: Show a => Text -> a -> [String]
+foundLines msg found = case lines' of
+  [] -> []
+  first : rest ->
+    unpack (msg <> ": " <> first) : (unpack . (T.replicate 9 " " <>) <$> rest)
+  where lines' = T.lines . pack $ show found

--- a/package.yaml
+++ b/package.yaml
@@ -54,6 +54,7 @@ library:
     - exceptions
     - filepath
     - hspec-core >= 2.8.1
+    - hspec-api >= 2.10 && < 3
     - iso8601-time
     - text
     - time


### PR DESCRIPTION
Hey there :wave:

I'm inclined to provide a stable API for Hspec formatters (and eventually other extensions) similar in spirit to what @chrisdone describes in his blog post [Immutable Publishing Policy](https://chrisdone.com/posts/ipp/).

In the past I tried hard to keep the public interface stable, but there are times where a new feature requires user visible changes.  The idea here is that we both (a) eliminate breakage while at the same time (b) are more free in what we do in `hspec-core` internally.

Preliminary docs are at https://github.com/hspec/hspec/blob/formatter-docs/doc/extending-hspec-formatter.md.

`Test.Hspec.Api.Format.V1` is a stable interface as long as you only use types provided by that module.  It's not safe to mix definitions from that module with definitions from `hspec-core`.  However, there is a function `liftFormatter` which can be used to convert a formatter to `hspec-core` types.

I used [hspec-junit-formatter](https://github.com/freckle/hspec-junit-formatter) to test drive this approach.

This aims at two things:

- Avoids any risk of future breakage by using a stable API that will never change. 
- Makes it easy to use the formatter with `hspec-discover`.

`Test.Hspec.JUnitFormatter` uses `Test.Hspec.Api.Format.V1` and follows the conventions described in the preliminary docs.  The interfaces of any other modules are unchanged.

If you folks have any feedback on the docs, the convention or the `hspec-api` package then please let me know.

**_NOTE:_** This is not a request for merge!  This is meant to give you an opportunity to give feedback before I release `hspec-api`.