### PR TITLE
feat: register +junit formatters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: freckle/stack-action@v5
+        with:
+          stack-build-arguments-test: >-
+            --test-arguments='--format progress+junit'
         env:
-          JUNIT_ENABLED: 1
           STACK_YAML: ${{ matrix.stack-yaml }}
 
       - if: success() || failure()

--- a/README.lhs
+++ b/README.lhs
@@ -54,6 +54,26 @@ hook3 :: Spec -> Spec
 hook3 = Formatter.add $ defaultJUnitConfig "test-suite"
 ```
 
+### Mixing Formatters
+
+In addition to the formatter named `junit`, this library also registers
+formatters named `{formatter}+junit` for every existing formatter. This allows
+doing something like `--format progress+junit` to produce output with `progress`
+while also producing a JUnit file though `junit`.
+
+The `add` hook can be thought of like `--format checks+junit`, so this extra
+registration allows for similar "add" behavior on top of non-default formatters.
+
+Once registered, they can be seen in Hspec's `--help`:
+
+```console
+  -f NAME  --format=NAME           use a custom formatter; this can be one of
+                                   junit, checks+junit, specdoc+junit,
+                                   progress+junit, failed-examples+junit,
+                                   silent+junit, checks, specdoc, progress,
+                                   failed-examples or silent
+```
+
 ### Environment Configuration
 
 To configure things via @JUNIT_@-prefixed environment variables, import

--- a/README.lhs
+++ b/README.lhs
@@ -96,7 +96,7 @@ before calling `hspec` in `main`:
 
 ```haskell
 main :: IO ()
-main = hspec $ FormatterEnv.whenEnabled FormatterEnv.add spec
+main = hspec $ FormatterEnv.register spec -- or use, or add
 
 spec :: Spec
 spec = describe "Addition" $ do

--- a/README.lhs
+++ b/README.lhs
@@ -45,7 +45,6 @@ hook2 :: Spec -> Spec
 hook2 = Formatter.register $ defaultJUnitConfig "test-suite"
 ```
 
-
 ### Adding a JUnit report
 
 To produce a JUnit report _in addition to normal output_, use `add`:
@@ -103,21 +102,6 @@ spec = describe "Addition" $ do
   it "adds" $ do
     2 + 2 `shouldBe` (4 :: Int)
 ```
-
-## Golden Testing
-
-This project's test suite uses [hspec-golden][] to generate an XML report for
-[`Example.hs`](./tests/Example.hs) and then compare that with golden XML files
-checked into the repository. If your work changes things in a
-functionally-correct way, but that diverges from the golden XML files, you need
-to regenerate them.
-
-1. Run `rm tests/golden*.xml`
-2. Run the specs again
-
-We maintain specific golden XML files for GHC 8.x vs 9.x, so you will need to
-re-run the test suite with at least one of each series to regenerate all the
-necessary files.
 
 ## Release
 

--- a/library/Test/Hspec/JUnit/Formatter.hs
+++ b/library/Test/Hspec/JUnit/Formatter.hs
@@ -21,6 +21,12 @@
 -- hook = Formatter.register defaultJUnitConfig
 -- @
 --
+-- __NOTE__: In addition to registering the @junit@ formatter, all functions of
+-- this module will register @{formatter}+junit@ formatters for every existing
+-- available @formatter@. This allows you to produce JUnit files in addition to
+-- non-default formats. For example, to produce output using @progress@ along
+-- with a JUnit file, use @--format progress+junit@.
+--
 -- See also,
 --
 -- - https://hspec.github.io/hspec-discover.html#spec-hooks
@@ -49,18 +55,35 @@ import Test.Hspec.JUnit.Format
 
 -- | Register 'junit' as an available formatter and use it by default
 use :: JUnitConfig -> SpecWith a -> SpecWith a
-use config = (modifyConfig (useFormatter $ formatter config) >>)
+use config = (modifyConfig (useFormatter f . registerAdditions f) >>)
+ where
+  f = formatter config
 
 -- | Register 'junit', and use it /in addition/ to the default
 add :: JUnitConfig -> SpecWith a -> SpecWith a
-add config = (modifyConfig (addFormatter $ formatter config) >>)
+add config = (modifyConfig (addFormatter f . registerAdditions f) >>)
+ where
+  f = formatter config
 
 -- | Register 'junit', but do not change the default
 register :: JUnitConfig -> SpecWith a -> SpecWith a
-register config = (modifyConfig (registerFormatter $ formatter config) >>)
+register config = (modifyConfig (registerFormatter f . registerAdditions f) >>)
+ where
+  f = formatter config
 
 formatter :: JUnitConfig -> (String, FormatConfig -> IO Format)
 formatter config = ("junit", junit config)
+
+registerAdditions :: (String, FormatConfig -> IO Format) -> Config -> Config
+registerAdditions f config =
+  config
+    { configAvailableFormatters =
+        -- registerFormatter puts it in the front, so we'll do the same
+        map (`combineFormat` liftFormatter f) existing <> existing
+    }
+ where
+  existing :: [(String, Core.FormatConfig -> IO Core.Format)]
+  existing = configAvailableFormatters config
 
 addFormatter :: (String, FormatConfig -> IO Format) -> Config -> Config
 addFormatter f = go . registerFormatter f
@@ -78,6 +101,12 @@ addFormatter f = go . registerFormatter f
 
 defaultFormat :: Core.FormatConfig -> IO Core.Format
 defaultFormat = V2.formatterToFormat V2.checks
+
+combineFormat
+  :: (String, Core.FormatConfig -> IO Core.Format)
+  -> (String, Core.FormatConfig -> IO Core.Format)
+  -> (String, Core.FormatConfig -> IO Core.Format)
+combineFormat (name1, f1) (name2, f2) = (name1 <> "+" <> name2, addFormat f1 f2)
 
 addFormat
   :: (Core.FormatConfig -> IO Core.Format)

--- a/package.yaml
+++ b/package.yaml
@@ -10,9 +10,6 @@ extra-doc-files:
   - README.md
   - CHANGELOG.md
 
-extra-source-files:
-  - tests/golden/**/*.xml
-
 category: Testing
 synopsis: A JUnit XML runner/formatter for hspec
 description: |

--- a/tests/SpecHook.hs
+++ b/tests/SpecHook.hs
@@ -6,4 +6,4 @@ import Test.Hspec
 import Test.Hspec.JUnit.Formatter.Env as Formatter
 
 hook :: Spec -> Spec
-hook = Formatter.whenEnabled Formatter.add
+hook = Formatter.register


### PR DESCRIPTION
In addition to registering the `junit` formatter itself, we now go
through each existing formatter and register `{that}+junit` formatters
for each.

This is useful because using `--format junit` will only produce a JUnit
file, and using `--format progress` will only output in the  progress
format (even if our `add` hook was used). There is no way to avoid this
behavior, but by registering `progress+junit` (for example), users are
able to print in `progress` and produce a JUnit file at the same time.
