### PR TITLE
chore: set renovate minimumReleaseAge to 1 day

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,5 @@
   "extends": [
     "local>freckle/renovate-config"
   ],
-  "minimumReleaseAge": "0 days"
+  "minimumReleaseAge": "1 days"
 }


### PR DESCRIPTION
`renovate.json` overrode the shared `freckle/renovate-config` preset's `minimumReleaseAge` down to `"0 days"`, which lets Renovate open a PR the instant a version is published. This sets it to `"1 days"` instead.

The floor matters for JS repos: pnpm 11+ refuses to install any package published within the last 1440 minutes, so a PR opened immediately fails the `--frozen-lockfile` install in CI until the package is a day old. `"1 days"` is the smallest value that clears that cutoff. It is applied uniformly to every non-archived repo in the org that carried the `"0 days"` override.